### PR TITLE
feat: GreenCanvas セル関係

### DIFF
--- a/app/test/page.tsx
+++ b/app/test/page.tsx
@@ -5,6 +5,14 @@ import GreenCanvas from "@/components/greens/GreenCanvas";
 
 export default function TestPage() {
   const [damageCells, setDamageCells] = useState<string[]>([]);
+  const [banCells, setBanCells] = useState<string[]>([
+    "cell_25_35",
+    "cell_26_35",
+  ]);
+  const [rainCells, setRainCells] = useState<string[]>([
+    "cell_35_40",
+    "cell_36_40",
+  ]);
 
   const handleCellClick = (cellId: string) => {
     console.log("クリックされたセル:", cellId);
@@ -17,11 +25,11 @@ export default function TestPage() {
 
   return (
     <div className="p-8">
-      <h1 className="text-2xl font-bold mb-4">GreenCanvas テスト</h1>
-      <p className="mb-4">ダメージセル: {damageCells.length}個</p>
       <GreenCanvas
         hole="1"
         damageCells={damageCells}
+        banCells={banCells}
+        rainCells={rainCells}
         onCellClick={handleCellClick}
       />
     </div>

--- a/components/greens/GreenCanvas.tsx
+++ b/components/greens/GreenCanvas.tsx
@@ -44,7 +44,9 @@ interface Props {
   hole: string;
   width?: number;
   height?: number;
-  damageCells: string[];
+  damageCells?: string[];
+  banCells?: string[];
+  rainCells?: string[];
   onCellClick?: (cellId: string) => void;
 }
 
@@ -68,6 +70,8 @@ export default function GreenCanvas({
   width = 600,
   height = 600,
   damageCells = [],
+  banCells = [],
+  rainCells = [],
   onCellClick,
 }: Props) {
   const [holeData, setHoleData] = useState<HoleData | null>(null);
@@ -192,6 +196,7 @@ export default function GreenCanvas({
           fill="#f97316"
         />
 
+        {/* 傷みセル */}
         {damageCells.map((cellId) => {
           const cell = holeData.cells.find((c) => c.id === cellId);
           if (!cell) return null;
@@ -203,6 +208,38 @@ export default function GreenCanvas({
               width={YD_TO_PX}
               height={YD_TO_PX}
               fill="rgba(239, 68, 68, 0.7)"
+            />
+          );
+        })}
+
+        {/* 禁止セル */}
+        {banCells.map((cellId) => {
+          const cell = holeData.cells.find((c) => c.id === cellId);
+          if (!cell) return null;
+          return (
+            <Rect
+              key={`ban-${cellId}`}
+              x={ydToPx(cell.x)}
+              y={ydToPx(cell.y)}
+              width={YD_TO_PX}
+              height={YD_TO_PX}
+              fill="rgba(75, 85, 99, 0.7)"
+            />
+          );
+        })}
+
+        {/* 雨天禁止セル */}
+        {rainCells.map((cellId) => {
+          const cell = holeData.cells.find((c) => c.id === cellId);
+          if (!cell) return null;
+          return (
+            <Rect
+              key={`rain-${cellId}`}
+              x={ydToPx(cell.x)}
+              y={ydToPx(cell.y)}
+              width={YD_TO_PX}
+              height={YD_TO_PX}
+              fill="rgba(59, 130, 246, 0.7)"
             />
           );
         })}


### PR DESCRIPTION
## 概要
ダメージ/禁止/雨天セルの表示とクリック編集機能

## 実施した内容
- Cell型定義追加
- 傷みセル描画（赤）
- セルクリック処理
- 禁止セル描画（グレー）
- 雨天禁止セル描画（青）

## スクショ
<img width="500" height="493" alt="スクリーンショット 2026-02-04 0 54 05" src="https://github.com/user-attachments/assets/2688f98c-dc52-4989-a2e9-eddfef2dd743" />


## 関連issue
Closes #5