### PR TITLE
feat: GreenCanvas 傾斜面描画

### DIFF
--- a/components/greens/GreenCanvas.tsx
+++ b/components/greens/GreenCanvas.tsx
@@ -395,7 +395,16 @@ export default function GreenCanvas({
         {holeData.slope ? (
           <Path
             data={scalePathToPixels(holeData.slope.upper.d)}
-            fill="000000"
+            fill="#7ed9a0"
+          />
+        ) : null}
+
+        {/* グリーン下段 */}
+
+        {holeData.slope ? (
+          <Path
+            data={scalePathToPixels(holeData.slope.lower.d)}
+            fill="#5fb8a0"
           />
         ) : null}
 


### PR DESCRIPTION
## 概要
傾斜データの上段・下段エリアをグリーン上に描画する

## 実施した内容
二段グリーンホール
- 上段（upper）面の描画
- 下段（lower）面の描画

## スクショ

<img width="672" height="672" alt="スクリーンショット 2026-02-05 11 38 30" src="https://github.com/user-attachments/assets/aaa3fcb5-26f9-40e1-b8da-53c723062124" />


## 関連issue
Closes #17