### PR TITLE
feat: 1ホール自動提案ロジック

### DIFF
--- a/lib/autoProposal.ts
+++ b/lib/autoProposal.ts
@@ -150,5 +150,10 @@ export function generateProposals(input: AutoProposalInput): Candidate[] {
   });
 
   // Step 3: フォールバック
-  return [];
+  if (excludedRoute.length === 0) {
+    // 過去ピン・導線の除外をスキップして返す
+    return excludedBoundary.map((c) => ({ x: c.x, y: c.y }));
+  }
+
+  return excludedRoute.map((c) => ({ x: c.x, y: c.y }));
 }


### PR DESCRIPTION
## 概要
1ホール分のピン位置候補を自動生成するロジックを実装

## 実施した内容
- lib/autoProposal.ts 新規作成
- 候補生成（グリッド交点の全探索）
- 除外フィルタ（禁止→雨天→ダメージ→傾斜→外周→過去ピン→導線被り）
- フォールバック（過去ピン・出口導線制限解除）

## 関連issue
Closes #36