### PR TITLE
feat: 9ホール分自動提案ロジック

### DIFF
--- a/lib/courseProposal.ts
+++ b/lib/courseProposal.ts
@@ -144,6 +144,22 @@ export function generateCourseProposal(
       );
       if (filtered.length > 0) pool = filtered;
     }
+
+    // ルール5: ランダム選択
+    const selected = pool[Math.floor(Math.random() * pool.length)];
+
+    // カウント更新
+    const selectedDepth = getDepthPosition(selected.y, hole.cells);
+    currentDepth[selectedDepth]++;
+
+    if (hole.isShortHole) {
+      usedShortHoleDepths.push(selectedDepth);
+    }
+
+    result.push({
+      holeNumber: hole.holeNumber,
+      selectedPin: selected,
+    });
   }
 
   return { holes: result };


### PR DESCRIPTION
## 概要
9ホール全体の位置バランスでピンを選択するロジックを実装

## 実施した内容
- lib/courseProposal.ts 新規作成
- 奥行き・左右の位置判定関数
- コース難易度に応じた奥行き分布テーブル
- 5つの選択ルール（ショートホール段分散→奥行き→難易度枠優先→左右→ランダム）

## 関連issue
Closes #38