### PR TITLE
feat: ユーザー管理画面実装

### DIFF
--- a/app/admin/users/page.tsx
+++ b/app/admin/users/page.tsx
@@ -10,6 +10,14 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
 
 type User = {
   id: string;
@@ -44,13 +52,63 @@ const mockUsers: User[] = [
 ];
 
 export default function UsersPage() {
-  const [users] = useState<User[]>(mockUsers);
+  const [users, setUsers] = useState<User[]>(mockUsers);
+  const [isOpen, setIsOpen] = useState(false);
+  const [editingUser, setEditingUser] = useState<User | null>(null);
+  const [name, setName] = useState("");
+  const [email, setEmail] = useState("");
+  const [role, setRole] = useState<"admin" | "staff">("staff");
+
+  function openAdd() {
+    setEditingUser(null);
+    setName("");
+    setEmail("");
+    setRole("staff");
+    setIsOpen(true);
+  }
+
+  function openEdit(user: User) {
+    setEditingUser(user);
+    setName(user.name);
+    setEmail(user.email);
+    setRole(user.role);
+    setIsOpen(true);
+  }
+
+  function handleSave() {
+    if (!email) return;
+    if (editingUser) {
+      setUsers((prev) =>
+        prev.map((u) =>
+          u.id === editingUser.id ? { ...u, name, email, role } : u,
+        ),
+      );
+    } else {
+      setUsers((prev) => [
+        ...prev,
+        {
+          id: String(Date.now()),
+          name,
+          email,
+          role,
+          createdAt: new Date().toISOString().split("T")[0],
+        },
+      ]);
+    }
+    setIsOpen(false);
+  }
+
+  function handleDelete() {
+    if (!editingUser) return;
+    setUsers((prev) => prev.filter((u) => u.id !== editingUser.id));
+    setIsOpen(false);
+  }
 
   return (
     <div className="p-4">
       <div className="flex items-center justify-between mb-4">
         <h1 className="text-xl font-bold">ユーザー管理</h1>
-        <Button>新規追加</Button>
+        <Button onClick={openAdd}>新規追加</Button>
       </div>
       <Table>
         <TableHeader>
@@ -72,7 +130,11 @@ export default function UsersPage() {
               </TableCell>
               <TableCell>{user.createdAt}</TableCell>
               <TableCell>
-                <Button variant="outline" size="sm">
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => openEdit(user)}
+                >
                   編集
                 </Button>
               </TableCell>
@@ -80,6 +142,45 @@ export default function UsersPage() {
           ))}
         </TableBody>
       </Table>
+
+      <Dialog open={isOpen} onOpenChange={setIsOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>
+              {editingUser ? "ユーザー編集" : "新規追加"}
+            </DialogTitle>
+          </DialogHeader>
+          <div className="space-y-4">
+            <div>
+              <Label>メール</Label>
+              <Input value={email} onChange={(e) => setEmail(e.target.value)} />
+            </div>
+            <div>
+              <Label>表示名</Label>
+              <Input value={name} onChange={(e) => setName(e.target.value)} />
+            </div>
+            <div>
+              <Label>権限</Label>
+              <select
+                value={role}
+                onChange={(e) => setRole(e.target.value as "admin" | "staff")}
+                className="w-full border rounded-md p-2"
+              >
+                <option value="staff">スタッフ</option>
+                <option value="admin">管理者</option>
+              </select>
+            </div>
+            <div className="flex gap-2">
+              <Button onClick={handleSave}>保存</Button>
+              {editingUser && (
+                <Button variant="destructive" onClick={handleDelete}>
+                  削除
+                </Button>
+              )}
+            </div>
+          </div>
+        </DialogContent>
+      </Dialog>
     </div>
   );
 }


### PR DESCRIPTION
## 概要
ユーザー管理画面（/admin/users）を実装

## 変更内容
- shadcn/ui Tableでユーザー一覧表示
- 新規追加モーダル（メール・表示名・権限）
- 編集モーダル（名前・権限変更）
- 削除機能

## スクショ
<img width="1440" height="778" alt="スクリーンショット 2026-02-15 21 05 16" src="https://github.com/user-attachments/assets/a091c15f-f9cd-4159-baa6-326d5509995b" />


## 関連Issue
closes #63
