### PR TITLE
feat: 自動提案画面のAPI連携

### DIFF
--- a/lib/autoSuggest.ts
+++ b/lib/autoSuggest.ts
@@ -1,0 +1,25 @@
+import axios from "@/lib/axios";
+
+export interface AutoSuggestData {
+  damage_cells: Record<
+    string,
+    { id: string; hole_number: number; x: number; y: number }[]
+  >;
+  ban_cells: Record<
+    string,
+    { id: string; hole_number: number; x: number; y: number }[]
+  >;
+  rain_cells: Record<
+    string,
+    { id: string; hole_number: number; x: number; y: number }[]
+  >;
+  past_pins: Record<
+    string,
+    { id: string; hole_number: number; x: number; y: number; date: string }[]
+  >;
+}
+
+export async function getAutoSuggestData(): Promise<AutoSuggestData> {
+  const res = await axios.get("/auto-suggest-data");
+  return res.data;
+}


### PR DESCRIPTION
## 概要
自動提案画面のデータ取得をAPIに切り替え

## 実施した内容
- getAutoSuggestData API関数作成（lib/autoSuggest.ts）
- ダッシュボードのセルデータ（damage, ban, rain）をAPI取得に変更
- 過去ピンデータをAPI取得に変更

## 関連issue
#77