### PR TITLE
fix: ロジックテストで発覚したバグ修正

### DIFF
--- a/components/admin/PinEditPanel.tsx
+++ b/components/admin/PinEditPanel.tsx
@@ -1,14 +1,7 @@
 import GreenCanvas from "@/components/greens/GreenCanvas";
 import { HolePin } from "@/lib/greenCanvas.geometry";
 import { Button } from "@/components/ui/button";
-import {
-  checkSession,
-  publishSession,
-  approveSession,
-  sendSession,
-  PinSession,
-} from "@/lib/pinSession";
-import api from "@/lib/axios";
+import { checkSession, publishSession, PinSession } from "@/lib/pinSession";
 
 interface PinEditPanelProps {
   editingHole: number;
@@ -21,18 +14,10 @@ interface PinEditPanelProps {
   onPinDragged: (pin: { id: string; x: number; y: number }) => void;
   onCellClick: (cellId: string) => void;
   onPinSave: () => void;
-  // セッション関連
   outSession: PinSession | null;
   inSession: PinSession | null;
   onOutSessionUpdate: (session: PinSession) => void;
   onInSessionUpdate: (session: PinSession) => void;
-  // confirmed確認
-  confirmedSessions: PinSession[];
-  onConfirmedSessionsUpdate: (sessions: PinSession[]) => void;
-  onReviewSession: (session: PinSession, pins: HolePin[]) => void;
-  // approved送信
-  approvedSessions: PinSession[];
-  onApprovedSessionsUpdate: (sessions: PinSession[]) => void;
 }
 
 export default function PinEditPanel({
@@ -50,11 +35,6 @@ export default function PinEditPanel({
   inSession,
   onOutSessionUpdate,
   onInSessionUpdate,
-  confirmedSessions,
-  onConfirmedSessionsUpdate,
-  onReviewSession,
-  approvedSessions,
-  onApprovedSessionsUpdate,
 }: PinEditPanelProps) {
   return (
     <div className="p-4">
@@ -100,11 +80,9 @@ export default function PinEditPanel({
       </div>
 
       <div className="mt-8 space-y-2">
-        {/* ピン保存 */}
         <Button className="w-full" onClick={onPinSave}>
           ピンを保存
         </Button>
-        {/* 編集完了 → checked */}
         <Button
           className="w-full"
           variant="outline"
@@ -119,7 +97,6 @@ export default function PinEditPanel({
         >
           編集完了
         </Button>
-        {/* スタッフに公開 → published */}
         <Button
           className="w-full"
           variant="outline"
@@ -135,105 +112,6 @@ export default function PinEditPanel({
           スタッフに公開
         </Button>
       </div>
-
-      {/* confirmed セッション確認エリア */}
-      {confirmedSessions.length > 0 && (
-        <div className="mt-8">
-          <h2 className="font-bold mb-4">確認待ちセッション</h2>
-          <div className="space-y-2">
-            {confirmedSessions.map((s) => (
-              <div
-                key={s.id}
-                className="flex items-center justify-between p-3 rounded bg-gray-50 border"
-              >
-                <div className="text-sm">
-                  <span className="font-bold">{s.course}</span>
-                  {s.target_date && ` - ${s.target_date}`}
-                  <span className="ml-2 text-gray-500">
-                    提出者: {s.submitted_by_name}
-                  </span>
-                </div>
-                <div className="flex gap-2">
-                  <Button
-                    variant="outline"
-                    size="sm"
-                    onClick={async () => {
-                      const res = await api.get(`/api/pin-sessions/${s.id}`);
-                      const pins: HolePin[] = res.data.pins.map(
-                        (p: { hole_number: number; x: number; y: number }) => ({
-                          hole: p.hole_number,
-                          x: p.x,
-                          y: p.y,
-                        }),
-                      );
-                      onReviewSession(s, pins);
-                    }}
-                  >
-                    確認
-                  </Button>
-                  <Button
-                    size="sm"
-                    onClick={async () => {
-                      try {
-                        await approveSession(s.id);
-                        onConfirmedSessionsUpdate(
-                          confirmedSessions.filter((cs) => cs.id !== s.id),
-                        );
-                        alert(`${s.course} を承認しました`);
-                      } catch (err) {
-                        console.error("承認エラー:", err);
-                        alert("承認に失敗しました");
-                      }
-                    }}
-                  >
-                    承認
-                  </Button>
-                </div>
-              </div>
-            ))}
-          </div>
-        </div>
-      )}
-
-      {/* approved セッション送信エリア */}
-      {approvedSessions.length > 0 && (
-        <div className="mt-8">
-          <h2 className="font-bold mb-4">送信待ちセッション</h2>
-          <div className="space-y-2">
-            {approvedSessions.map((s) => (
-              <div
-                key={s.id}
-                className="flex items-center justify-between p-3 rounded bg-gray-50 border"
-              >
-                <div className="text-sm">
-                  <span className="font-bold">{s.course}</span>
-                  {s.target_date && ` - ${s.target_date}`}
-                  <span className="ml-2 text-gray-500">
-                    承認者: {s.approved_by}
-                  </span>
-                </div>
-                <Button
-                  size="sm"
-                  onClick={async () => {
-                    try {
-                      await sendSession(s.id);
-                      onApprovedSessionsUpdate(
-                        approvedSessions.filter((as) => as.id !== s.id),
-                      );
-                      alert(`${s.course} をマスター室に送信しました`);
-                    } catch (err) {
-                      console.error("送信エラー:", err);
-                      alert("送信に失敗しました");
-                    }
-                  }}
-                >
-                  マスター室に送信
-                </Button>
-              </div>
-            ))}
-          </div>
-        </div>
-      )}
     </div>
   );
 }

--- a/lib/autoSuggest.ts
+++ b/lib/autoSuggest.ts
@@ -20,6 +20,6 @@ export interface AutoSuggestData {
 }
 
 export async function getAutoSuggestData(): Promise<AutoSuggestData> {
-  const res = await axios.get("/auto-suggest-data");
+  const res = await axios.get("/api/auto-suggest-data");
   return res.data;
 }


### PR DESCRIPTION
# 概要

セッションフロー通し確認で発覚したバグを修正した

## 修正内容

### フロントエンド
- autoSuggest.tsでAPIパスの先頭に/apiをつけ忘れを修正
- 確認待ち・送信待ちセッション一覧がピン編集モードでしか見えない状態だったので、管理者画面の下部に常時表示するよう変更
- 上記に伴い、PinEditPanelの責務をピン編集+ステータス遷移のみに整理

## テスト結果

全ステータス遷移（draft → checked → published → confirmed → approved → sent）の通し確認完了

## 関連issue

Closes #87