### PR TITLE
feat: 自動提案パネルに天気API表示

### DIFF
--- a/components/admin/AutoSuggestPanel.tsx
+++ b/components/admin/AutoSuggestPanel.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Calendar } from "@/components/ui/calendar";
 import { Label } from "@/components/ui/label";
@@ -17,6 +18,7 @@ import {
 } from "@/components/ui/select";
 import { CourseDifficulty } from "@/lib/courseProposal";
 import { Target } from "lucide-react";
+import { fetchWeatherForecast, DailyForecast } from "@/lib/weather";
 
 interface AutoSuggestPanelProps {
   selectedDate: Date;
@@ -31,12 +33,19 @@ interface AutoSuggestPanelProps {
 export default function AutoSuggestPanel({
   selectedDate,
   onDateChange,
-  isRainyDay,
+  isRainyDay: isRainyDayProp,
   onRainyDayChange,
   courseDifficulty,
   onDifficultyChange,
   onGenerate,
 }: AutoSuggestPanelProps) {
+  const [weatherForecasts, setWeatherForecasts] = useState<DailyForecast[]>([]);
+
+  // 天気予報を取得
+  useEffect(() => {
+    fetchWeatherForecast().then(setWeatherForecasts);
+  }, []);
+
   return (
     <div className="flex-1 min-w-0 bg-card rounded-xl shadow-sm border overflow-hidden flex flex-col">
       {/* ヘッダーバー */}
@@ -47,6 +56,7 @@ export default function AutoSuggestPanel({
 
       {/* コンテンツ */}
       <div className="flex-1 p-4 space-y-4">
+        {/* 日付 */}
         <div>
           <Label>日付</Label>
           <Popover>
@@ -64,10 +74,32 @@ export default function AutoSuggestPanel({
             </PopoverContent>
           </Popover>
         </div>
+
+        {/* 天気予報 */}
+        {weatherForecasts.length > 0 && (
+          <div>
+            <Label>天気予報</Label>
+            <div className="grid grid-cols-5 gap-1 text-center mt-1">
+              {weatherForecasts.map((weather) => (
+                <div key={weather.date} className="text-xs">
+                  <div>{weather.date.slice(8)}</div>
+                  <div className="text-lg">{weather.emoji}</div>
+                  <div>
+                    {weather.tempMin}°/{weather.tempMax}°
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {/* 雨天モード */}
         <div className="flex items-center gap-2">
-          <Switch checked={isRainyDay} onCheckedChange={onRainyDayChange} />
+          <Switch checked={isRainyDayProp} onCheckedChange={onRainyDayChange} />
           <Label>雨天モード</Label>
         </div>
+
+        {/* コース難易度 */}
         <div>
           <Label>コース難易度</Label>
           <Select
@@ -84,6 +116,8 @@ export default function AutoSuggestPanel({
             </SelectContent>
           </Select>
         </div>
+
+        {/* 自動提案実行 */}
         <Button className="w-full" onClick={onGenerate}>
           自動提案を実行
         </Button>

--- a/lib/weather.ts
+++ b/lib/weather.ts
@@ -1,0 +1,50 @@
+/**
+ * Open-Meteo APIで5日間天気予報を取得（APIキー不要）
+ */
+
+const LAT = 35.6762;
+const LON = 139.6503;
+
+const DAYS = ["日", "月", "火", "水", "木", "金", "土"];
+
+function getWeather(code: number): { emoji: string; label: string } {
+  if (code <= 1) return { emoji: "☀️", label: "晴れ" };
+  if (code <= 3) return { emoji: "☁️", label: "曇り" };
+  if (code <= 67) return { emoji: "🌧️", label: "雨" };
+  return { emoji: "🌨️", label: "雪" };
+}
+
+export interface DailyForecast {
+  date: string;
+  dayOfWeek: string;
+  emoji: string;
+  label: string;
+  tempMax: number;
+  tempMin: number;
+  precipProb: number;
+}
+
+export async function fetchWeatherForecast(): Promise<DailyForecast[]> {
+  try {
+    const url = `https://api.open-meteo.com/v1/forecast?latitude=${LAT}&longitude=${LON}&daily=weather_code,temperature_2m_max,temperature_2m_min,precipitation_probability_max&timezone=Asia/Tokyo&forecast_days=5`;
+    const res = await fetch(url);
+    if (!res.ok) throw new Error(`API error: ${res.status}`);
+    const data = await res.json();
+
+    return data.daily.time.map((date: string, i: number) => {
+      const w = getWeather(data.daily.weather_code[i]);
+      return {
+        date,
+        dayOfWeek: DAYS[new Date(date).getDay()],
+        emoji: w.emoji,
+        label: w.label,
+        tempMax: Math.round(data.daily.temperature_2m_max[i]),
+        tempMin: Math.round(data.daily.temperature_2m_min[i]),
+        precipProb: data.daily.precipitation_probability_max[i] || 0,
+      };
+    });
+  } catch (err) {
+    console.error("天気予報取得エラー:", err);
+    return [];
+  }
+}


### PR DESCRIPTION
## 概要
自動提案パネルにOpen-Meteo天気APIで5日間予報を表示する。

## 実施した内容
- lib/weather.ts 新規作成（Open-Meteo API）
- components/admin/AutoSuggestPanel.tsx に天気予報カード表示

## 関連issue
Closes #101