### PR TITLE
fix: 自動提案パネルの見切れを修正

### DIFF
--- a/components/admin/AutoSuggestPanel.tsx
+++ b/components/admin/AutoSuggestPanel.tsx
@@ -74,16 +74,16 @@ export default function AutoSuggestPanel({
       <div className="flex-shrink-0 h-[44px] px-4 bg-muted border-b border-default flex items-center justify-center"></div>
 
       {/* コンテンツ */}
-      <div className="flex-1 p-4 space-y-5">
+      <div className="flex-1 min-h-0 flex flex-col justify-evenly p-4">
         {/* 選択日付の表示 */}
         <div className="text-center">
-          <div className="text-2xl font-bold">
+          <div className="text-2xl font-bold leading-tight">
             {format(selectedDate, "yyyy年M月d日", { locale: ja })}
           </div>
-          <div className="text-lg text-blue-500 font-bold">
+          <div className="text-base text-blue-500 font-bold">
             （{format(selectedDate, "EEEE", { locale: ja })}）
           </div>
-          <div className="mt-1 flex items-center justify-center gap-3 text-base">
+          <div className="mt-1 flex items-center justify-center gap-3 text-sm">
             {schedule?.event_name && (
               <span className="bg-blue-100 text-blue-700 px-2 py-0.5 rounded text-xs font-medium">
                 {schedule.event_name}
@@ -189,19 +189,17 @@ export default function AutoSuggestPanel({
         </div>
 
         {/* 自動提案実行 */}
-        <div className="py-3">
-          <Button
-            className={`w-full py-3 rounded-xl font-bold flex items-center justify-center gap-2 ${
-              disabled
-                ? "bg-gray-200 text-gray-400 cursor-not-allowed"
-                : "bg-gradient-to-r from-green-500 to-green-600 text-white hover:from-green-600 hover:to-green-700"
-            }`}
-            onClick={onGenerate}
-            disabled={disabled}
-          >
-            <Rocket size={16} /> 自動提案生成
-          </Button>
-        </div>
+        <Button
+          className={`w-full py-3 rounded-xl font-bold flex items-center justify-center gap-2 ${
+            disabled
+              ? "bg-gray-200 text-gray-400 cursor-not-allowed"
+              : "bg-gradient-to-r from-green-500 to-green-600 text-white hover:from-green-600 hover:to-green-700"
+          }`}
+          onClick={onGenerate}
+          disabled={disabled}
+        >
+          <Rocket size={16} /> 自動提案生成
+        </Button>
 
         {/* ワークフロー説明 */}
         <div className="bg-blue-50 rounded-lg p-3 border border-blue-200">
@@ -223,7 +221,7 @@ export default function AutoSuggestPanel({
             </li>
             <li className="list-decimal">
               <span className="inline-block w-[8em]">最終確認</span>-
-              管理者がスタッフの現場確認報告を受けて再調整
+              管理者がスタッフの確認報告を受けて再調整
             </li>
             <li className="list-decimal">
               <span className="inline-block w-[8em]">提案送信</span>-


### PR DESCRIPTION
## 概要
ダッシュボード右側の自動提案パネル下部のワークフロー説明が画面内に収まらず見切れる問題を修正。

## 実施した内容
- コンテンツを justify-evenlyで均等配置し、パネル高さ全体を使い切るよう調整

## 関連issue
Closes #120