### PR TITLE
refactor: マジックナンバーを定数化

### DIFF
--- a/lib/courseProposal.ts
+++ b/lib/courseProposal.ts
@@ -28,6 +28,8 @@ type DepthPosition = "front" | "middle" | "back";
 type HorizontalPosition = "left" | "center" | "right";
 
 //定数
+const GREEN_CENTER_X = 30; // グリーン中央X座標（ヤード）
+
 const DEPTH_DISTRIBUTION: Record<
   CourseDifficulty,
   { back: number; middle: number; front: number }
@@ -144,7 +146,7 @@ export function generateCourseProposal(
 
     // ルール4: グリーン中央に近い候補を選択
     const holeConfig = HOLE_CONFIGS[String(hole.holeNumber).padStart(2, "0")];
-    const centerX = 30;
+    const centerX = GREEN_CENTER_X;
     const centerY =
       (holeConfig.centerLineMarks.front.y + holeConfig.centerLineMarks.back.y) /
       2;


### PR DESCRIPTION
## 変更内容

autoProposal.ts と courseProposal.ts のマジックナンバーを定数化した。

## 追加した定数

**autoProposal.ts**
- SAME_POSITION_THRESHOLD = 1 — 同一座標とみなす距離（ヤード）
- ROUTE_OVERLAP_ANGLE = 10 — 導線被り判定角度（度）
- RECENT_PIN_COUNT = 2 — 直近ピン制限の対象数（前回・前々回）
- MEDIUM_PAST_START = 2 — 中期ピンの開始インデックス（3回前）
- MEDIUM_PAST_END = 4 — 中期ピンの終了インデックス（5回前）

**courseProposal.ts**
- GREEN_CENTER_X = 30 — グリーン中央X座標（ヤード）

### 関連Issue

closes #142