### PR TITLE
fix: handleSave/handleDeleteでAPIを呼ぶように修正

### DIFF
--- a/app/admin/schedule/page.tsx
+++ b/app/admin/schedule/page.tsx
@@ -85,25 +85,36 @@ export default function SchedulePage() {
     setSelectedDate(dateStr);
   }
 
-  function handleSave() {
+  async function handleSave() {
     if (!selectedDate) return;
     if (!eventName && !groupCount) return;
-    setSchedules((prev) => [
-      ...prev.filter((s) => s.date !== selectedDate),
-      {
-        id: "",
+
+    const existing = getExisting(selectedDate);
+    if (existing?.id) {
+      await api.put(`/api/schedules/${existing.id}`, {
+        event_name: eventName || null,
+        group_count: groupCount ? Number(groupCount) : null,
+      });
+    } else {
+      await api.post("/api/schedules", {
         date: selectedDate,
         event_name: eventName || null,
         group_count: groupCount ? Number(groupCount) : null,
-        notes: null,
-      },
-    ]);
+      });
+    }
+
+    await fetchSchedules();
     setSelectedDate(null);
   }
 
-  function handleDelete() {
+  async function handleDelete() {
     if (!selectedDate) return;
-    setSchedules((prev) => prev.filter((s) => s.date !== selectedDate));
+    const existing = getExisting(selectedDate);
+    if (existing?.id) {
+      await api.delete(`/api/schedules/${existing.id}`);
+    }
+
+    await fetchSchedules();
     setSelectedDate(null);
   }
 


### PR DESCRIPTION
## 概要
予定表ページの保存・削除がローカルstateのみ更新でAPIを呼んでいなかったバグを修正

## 実施した内容
- handleSave: 既存データがあれば PUT、なければ POST を呼ぶように修正
- handleDelete: DELETE を呼ぶように修正
- 成功後に fetchSchedules で最新データを再取得

Closes #146