### PR TITLE
refactor: holeData読み込みをuseHoleDataカスタムフックに統一

### DIFF
--- a/components/greens/GreenCanvas.tsx
+++ b/components/greens/GreenCanvas.tsx
@@ -33,6 +33,7 @@ import {
   scalePathToPixels,
   ydToPx,
 } from "@/lib/greenCanvas.convert";
+import { useHoleData } from "@/hooks/useHoleData";
 
 interface Props {
   hole: string;
@@ -80,15 +81,7 @@ export default function GreenCanvas({
   showExitRoute = true,
   isRainyDay = false,
 }: Props) {
-  const [holeData, setHoleData] = useState<HoleData | null>(null);
-
-  useEffect(() => {
-    const paddedHole = hole.padStart(2, "0");
-    fetch(`/greens/hole_${paddedHole}.json`)
-      .then((res) => res.json())
-      .then((data) => setHoleData(data))
-      .catch((err) => console.error("JSON読み込みエラー:", err));
-  }, [hole]);
+  const holeData = useHoleData(hole);
 
   if (!holeData) {
     return <div>読み込み中...</div>;

--- a/components/greens/GreenCardPDF.tsx
+++ b/components/greens/GreenCardPDF.tsx
@@ -14,6 +14,7 @@ import {
   scalePathToPixels,
   ydToPx,
 } from "@/lib/greenCanvas.convert";
+import { useHoleData } from "@/hooks/useHoleData";
 
 interface Props {
   hole: string;
@@ -26,15 +27,7 @@ const DEPTH_FONT_SIZE = 80;
 const HORIZONTAL_FONT_SIZE = 40;
 
 export default function GreenCardPDF({ hole, currentPin }: Props) {
-  const [holeData, setHoleData] = useState<HoleData | null>(null);
-
-  useEffect(() => {
-    const paddedHole = hole.padStart(2, "0");
-    fetch(`/greens/hole_${paddedHole}.json`)
-      .then((res) => res.json())
-      .then((data) => setHoleData(data))
-      .catch((err) => console.error("JSON読み込みエラー:", err));
-  }, [hole]);
+  const holeData = useHoleData(hole);
 
   if (!holeData) {
     return <div>読み込み中...</div>;

--- a/components/greens/GreenCardPDFExport.tsx
+++ b/components/greens/GreenCardPDFExport.tsx
@@ -9,7 +9,12 @@ import {
   getBoundaryIntersectionX,
   getBoundaryIntersectionY,
 } from "@/lib/greenCanvas.geometry";
-import { CANVAS_SIZE, scalePathToPixels, ydToPx } from "@/lib/greenCanvas.convert";
+import {
+  CANVAS_SIZE,
+  scalePathToPixels,
+  ydToPx,
+} from "@/lib/greenCanvas.convert";
+import { useHoleData } from "@/hooks/useHoleData";
 
 interface Props {
   hole: string;
@@ -46,15 +51,7 @@ export default function GreenCardPDFExport({
   height = 240,
   currentPin,
 }: Props) {
-  const [holeData, setHoleData] = useState<HoleData | null>(null);
-
-  useEffect(() => {
-    const paddedHole = hole.padStart(2, "0");
-    fetch(`/greens/hole_${paddedHole}.json`)
-      .then((res) => res.json())
-      .then((data) => setHoleData(data))
-      .catch((err) => console.error("JSON読み込みエラー:", err));
-  }, [hole]);
+  const holeData = useHoleData(hole);
 
   if (!holeData) {
     return <div>読み込み中...</div>;

--- a/hooks/useHoleData.ts
+++ b/hooks/useHoleData.ts
@@ -1,0 +1,16 @@
+import { useState, useEffect } from "react";
+import { HoleData } from "@/lib/greenCanvas.geometry";
+
+export function useHoleData(hole: string): HoleData | null {
+  const [holeData, setHoleData] = useState<HoleData | null>(null);
+
+  useEffect(() => {
+    const paddedHole = hole.padStart(2, "0");
+    fetch(`/greens/hole_${paddedHole}.json`)
+      .then((res) => res.json())
+      .then((data) => setHoleData(data))
+      .catch((err) => console.error("JSON読み込みエラー:", err));
+  }, [hole]);
+
+  return holeData;
+}


### PR DESCRIPTION
## 概要
3箇所で重複していた holeData の JSON読み込み処理をカスタムフックに統一

## 実施した内容
- hooks/useHoleData.ts 作成
- GreenCanvas.tsx のJSON読み込みをフックに変更
- GreenCardPDF.tsx のJSON読み込みをフックに変更
- GreenCardPDFExport.tsx のJSON読み込みをフックに変更

Closes #152