### PR TITLE
refactor: ResizeObserverのカスタムフック化

### DIFF
--- a/app/admin/cells/page.tsx
+++ b/app/admin/cells/page.tsx
@@ -12,6 +12,7 @@ import {
   deleteCellGroup,
   CellGroup,
 } from "@/lib/cellGroups";
+import { useContainerSize } from "@/hooks/useContainerSize";
 
 type CellType = "damage" | "ban" | "rain";
 
@@ -50,41 +51,22 @@ export default function CellsEditPage() {
   const [saving, setSaving] = useState(false);
 
   // グリッドサイズ
-  const gridContainerRef = useRef<HTMLDivElement>(null);
-  const [gridScale, setGridScale] = useState(0.65);
+  const [gridContainerRef, gridContainerSize] = useContainerSize();
+  const gridScale =
+    gridContainerSize.width > 0
+      ? Math.min(
+          gridContainerSize.width / 752,
+          gridContainerSize.height / 880,
+          1,
+        )
+      : 0.65;
 
-  useEffect(() => {
-    const container = gridContainerRef.current;
-    if (!container) return;
-
-    const updateGridScale = () => {
-      const { clientWidth, clientHeight } = container;
-      const scaleX = clientWidth / 752; // グリッド固定幅
-      const scaleY = clientHeight / 880; // カード(240+40)×3 + gap×2
-      setGridScale(Math.min(scaleX, scaleY, 1));
-    };
-
-    updateGridScale();
-    const observer = new ResizeObserver(updateGridScale);
-    observer.observe(container);
-    return () => observer.disconnect();
-  }, []);
-  const canvasContainerRef = useRef<HTMLDivElement>(null);
-  const [canvasSize, setCanvasSize] = useState(400);
-
-  useEffect(() => {
-    const container = canvasContainerRef.current;
-    if (!container) return;
-
-    const observer = new ResizeObserver((entries) => {
-      for (const entry of entries) {
-        const { width, height } = entry.contentRect;
-        setCanvasSize(Math.floor(Math.min(width, height)));
-      }
-    });
-    observer.observe(container);
-    return () => observer.disconnect();
-  }, []);
+  // キャンバスサイズ
+  const [canvasContainerRef, canvasContainerSize] = useContainerSize();
+  const canvasSize =
+    Math.floor(
+      Math.min(canvasContainerSize.width, canvasContainerSize.height),
+    ) || 400;
 
   // 全グループ取得
   useEffect(() => {

--- a/app/staff/hole/[id]/page.tsx
+++ b/app/staff/hole/[id]/page.tsx
@@ -7,6 +7,7 @@ import { ChevronLeft, ChevronRight } from "lucide-react";
 import api from "@/lib/axios";
 import { ThemeToggle } from "@/components/theme/ThemeToggle";
 import { getPinSessionDetail } from "@/lib/pinSession";
+import { useContainerSize } from "@/hooks/useContainerSize";
 
 export default function StaffHoleEditPage() {
   const params = useParams();
@@ -26,8 +27,6 @@ export default function StaffHoleEditPage() {
     { id: string; x: number; y: number } | undefined
   >(undefined);
   const [pinDbId, setPinDbId] = useState<string | null>(null);
-  const [canvasSize, setCanvasSize] = useState(400);
-  const containerRef = useRef<HTMLDivElement>(null);
   const [isRainyDay, setIsRainyDay] = useState(false);
   const [banCells, setBanCells] = useState<string[]>([]);
   const [damageCells, setDamageCells] = useState<string[]>([]);
@@ -35,16 +34,9 @@ export default function StaffHoleEditPage() {
   const [pastPins, setPastPins] = useState<
     { id: string; x: number; y: number; date?: string }[]
   >([]);
-
-  useEffect(() => {
-    if (!containerRef.current) return;
-    const observer = new ResizeObserver((entries) => {
-      const { width, height } = entries[0].contentRect;
-      setCanvasSize(Math.floor(Math.min(width, height)));
-    });
-    observer.observe(containerRef.current);
-    return () => observer.disconnect();
-  }, []);
+  const [containerRef, containerSize] = useContainerSize();
+  const canvasSize =
+    Math.floor(Math.min(containerSize.width, containerSize.height)) || 400;
 
   useEffect(() => {
     if (!sessionId) return;

--- a/components/admin/CourseGridPanel.tsx
+++ b/components/admin/CourseGridPanel.tsx
@@ -2,6 +2,7 @@ import { useRef, useState, useEffect, useCallback } from "react";
 import GreenCardGridPDF from "@/components/greens/GreenCardGridPDF";
 import { HolePin } from "@/lib/greenCanvas.geometry";
 import { Button } from "@/components/ui/button";
+import { useContainerSize } from "@/hooks/useContainerSize";
 
 // GreenCardGridPDFの固定サイズ（240px × 3 + gap 16px × 2 = 752px）
 const GRID_INTRINSIC_WIDTH = 752;
@@ -24,23 +25,15 @@ export default function CourseGridPanel({
   selectedDate,
   onDateChange,
 }: CourseGridPanelProps) {
-  const containerRef = useRef<HTMLDivElement>(null);
-  const [scale, setScale] = useState(0.65);
-
-  const updateScale = useCallback(() => {
-    if (!containerRef.current) return;
-    const { clientWidth, clientHeight } = containerRef.current;
-    const scaleX = clientWidth / GRID_INTRINSIC_WIDTH;
-    const scaleY = clientHeight / GRID_INTRINSIC_HEIGHT;
-    setScale(Math.min(scaleX, scaleY, 1));
-  }, []);
-
-  useEffect(() => {
-    updateScale();
-    const observer = new ResizeObserver(updateScale);
-    if (containerRef.current) observer.observe(containerRef.current);
-    return () => observer.disconnect();
-  }, [updateScale]);
+  const [containerRef, containerSize] = useContainerSize();
+  const scale =
+    containerSize.width > 0
+      ? Math.min(
+          containerSize.width / GRID_INTRINSIC_WIDTH,
+          containerSize.height / GRID_INTRINSIC_HEIGHT,
+          1,
+        )
+      : 0.65;
   return (
     <div className="flex-1 min-w-0 bg-card rounded-xl shadow-sm border overflow-hidden flex flex-col">
       {/* ヘッダー: 日付ピッカー + ステータス */}

--- a/components/admin/PinEditPanel.tsx
+++ b/components/admin/PinEditPanel.tsx
@@ -5,6 +5,7 @@ import { HolePin, Pin } from "@/lib/greenCanvas.geometry";
 import { Button } from "@/components/ui/button";
 import { MapPin, Save, Flame, Ban, CloudRain } from "lucide-react";
 import { useState, useRef, useEffect } from "react";
+import { useContainerSize } from "@/hooks/useContainerSize";
 
 interface PinEditPanelProps {
   editingHole: number;
@@ -34,23 +35,11 @@ export default function PinEditPanel({
   const [showDamage, setShowDamage] = useState(true);
   const [showBan, setShowBan] = useState(true);
   const [showRain, setShowRain] = useState(isRainyDay);
-  const canvasContainerRef = useRef<HTMLDivElement>(null);
-  const [canvasSize, setCanvasSize] = useState(400);
-
-  useEffect(() => {
-    const container = canvasContainerRef.current;
-    if (!container) return;
-
-    const observer = new ResizeObserver((entries) => {
-      for (const entry of entries) {
-        const { width, height } = entry.contentRect;
-        setCanvasSize(Math.floor(Math.min(width, height)));
-      }
-    });
-    observer.observe(container);
-    return () => observer.disconnect();
-  }, []);
-
+  const [canvasContainerRef, canvasContainerSize] = useContainerSize();
+  const canvasSize =
+    Math.floor(
+      Math.min(canvasContainerSize.width, canvasContainerSize.height),
+    ) || 400;
   return (
     <div className="flex-1 min-w-0 bg-white rounded-xl shadow-sm border overflow-hidden flex flex-col">
       {/* ヘッダーバー */}

--- a/hooks/useContainerSize.ts
+++ b/hooks/useContainerSize.ts
@@ -1,0 +1,28 @@
+import { useState, useEffect, useRef } from "react";
+
+export function useContainerSize(): [
+  React.RefObject<HTMLDivElement | null>,
+  { width: number; height: number },
+] {
+  const ref = useRef<HTMLDivElement>(null);
+  const [size, setSize] = useState({ width: 0, height: 0 });
+
+  useEffect(() => {
+    const container = ref.current;
+    if (!container) return;
+
+    const update = () => {
+      setSize({
+        width: container.clientWidth,
+        height: container.clientHeight,
+      });
+    };
+
+    update();
+    const observer = new ResizeObserver(update);
+    observer.observe(container);
+    return () => observer.disconnect();
+  }, []);
+
+  return [ref, size];
+}


### PR DESCRIPTION
## 概要
5箇所で重複していたResizeObserverパターンをカスタムフックに統一

## 実施した内容
- hooks/useContainerSize.ts 作成
- components/admin/PinEditPanel.tsx のResizeObserverをフックに変更
- app/staff/hole/[id]/page.tsx のResizeObserverをフックに変更
- app/admin/cells/page.tsx のResizeObserver2箇所をフックに変更
- components/admin/CourseGridPanel.tsx のResizeObserverをフックに変更

Closes #154