### PR TITLE
refactor: 型定義の集約

### DIFF
--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -26,6 +26,7 @@ import { ShieldCheck, Eye, Send, ClipboardList } from "lucide-react";
 import CourseGridPanel from "@/components/admin/CourseGridPanel";
 import AutoSuggestPanel from "@/components/admin/AutoSuggestPanel";
 import PinEditPanel from "@/components/admin/PinEditPanel";
+import { PinResponse } from "@/types/api";
 
 // ステータスバッジ
 function StatusBadge({ session }: { session: PinSession | null }) {
@@ -122,25 +123,21 @@ export default function DashboardPage() {
       if (out) {
         const outDetail = await getPinSessionDetail(out.id);
         const pins =
-          outDetail.pins?.map(
-            (p: { hole_number: number; x: number; y: number }) => ({
-              hole: p.hole_number,
-              x: p.x,
-              y: p.y,
-            }),
-          ) || [];
+          outDetail.pins?.map((p: PinResponse) => ({
+            hole: p.hole_number,
+            x: p.x,
+            y: p.y,
+          })) || [];
         allPins.push(...pins);
       }
       if (in_) {
         const inDetail = await getPinSessionDetail(in_.id);
         const pins =
-          inDetail.pins?.map(
-            (p: { hole_number: number; x: number; y: number }) => ({
-              hole: p.hole_number,
-              x: p.x,
-              y: p.y,
-            }),
-          ) || [];
+          inDetail.pins?.map((p: PinResponse) => ({
+            hole: p.hole_number,
+            x: p.x,
+            y: p.y,
+          })) || [];
         allPins.push(...pins);
       }
       setCoursePins(allPins);

--- a/app/admin/pdf-preview/page.tsx
+++ b/app/admin/pdf-preview/page.tsx
@@ -13,6 +13,7 @@ import {
   getPinSessionDetail,
 } from "@/lib/pinSession";
 import api from "@/lib/axios";
+import { PinResponse } from "@/types/api";
 
 const CARD_SIZE = 240;
 
@@ -198,13 +199,11 @@ function PDFPreviewContent() {
 
           const detail = await getPinSessionDetail(s.id);
           const sessionPins =
-            detail.pins?.map(
-              (p: { hole_number: number; x: number; y: number }) => ({
-                hole: p.hole_number,
-                x: p.x,
-                y: p.y,
-              }),
-            ) || [];
+            detail.pins?.map((p: PinResponse) => ({
+              hole: p.hole_number,
+              x: p.x,
+              y: p.y,
+            })) || [];
           allPins.push(...sessionPins);
         }
 

--- a/components/staff/StaffCoursePage.tsx
+++ b/components/staff/StaffCoursePage.tsx
@@ -11,6 +11,7 @@ import {
 } from "@/lib/pinSession";
 import { HolePin } from "@/lib/greenCanvas.geometry";
 import { ThemeToggle } from "@/components/theme/ThemeToggle";
+import { PinResponse } from "@/types/api";
 
 function formatDate(dateStr: string | null): string {
   if (!dateStr) return "";
@@ -65,13 +66,11 @@ export default function StaffCoursePage({ course }: StaffCoursePageProps) {
           setSession(latest);
 
           const detail = await getPinSessionDetail(latest.id);
-          const sessionPins: HolePin[] = detail.pins.map(
-            (p: { hole_number: number; x: number; y: number }) => ({
-              hole: p.hole_number,
-              x: p.x,
-              y: p.y,
-            }),
-          );
+          const sessionPins: HolePin[] = detail.pins.map((p: PinResponse) => ({
+            hole: p.hole_number,
+            x: p.x,
+            y: p.y,
+          }));
           setPins(sessionPins);
         }
       } catch (err) {

--- a/types/api.ts
+++ b/types/api.ts
@@ -1,0 +1,8 @@
+/** ピンのAPIレスポンス型 */
+export interface PinResponse {
+  id: string;
+  hole_number: number;
+  x: number;
+  y: number;
+  session_id?: string;
+}


### PR DESCRIPTION
## 概要
複数ファイルで重複していたピンのインライン型を types/api.ts に集約

## 実施した内容
- types/api.ts 作成（PinResponse型）
- admin/page.tsx のインライン型をimportに変更
- admin/pdf-preview/page.tsx のインライン型をimportに変更
- components/staff/StaffCoursePage.tsx のインライン型をimportに変更

Closes #156