### PR TITLE
fix: 未使用import・console.logの削除

### DIFF
--- a/app/admin/cells/page.tsx
+++ b/app/admin/cells/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useRef } from "react";
+import { useState, useEffect } from "react";
 import { Button } from "@/components/ui/button";
 import { PageHeader } from "@/components/layout/PageHeader";
 import { Grid3x3, Pencil, Save, Flame, Ban, CloudRain } from "lucide-react";

--- a/app/admin/pdf-preview/page.tsx
+++ b/app/admin/pdf-preview/page.tsx
@@ -9,10 +9,8 @@ import PDFDocument from "@/components/pdf/PDFDocument";
 import {
   getPinSessions,
   sendSession,
-  PinSession,
   getPinSessionDetail,
 } from "@/lib/pinSession";
-import api from "@/lib/axios";
 import { PinResponse } from "@/types/api";
 
 const CARD_SIZE = 240;

--- a/app/admin/users/page.tsx
+++ b/app/admin/users/page.tsx
@@ -84,7 +84,6 @@ export default function UsersPage() {
   }
 
   async function handleDelete() {
-    console.log("handleSave called", { email, name, password, role });
     if (!editingUser) return;
     await api.delete(`/api/users/${editingUser.id}`);
     setIsOpen(false);

--- a/app/staff/hole/[id]/page.tsx
+++ b/app/staff/hole/[id]/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useRef } from "react";
+import { useState, useEffect } from "react";
 import { useParams, useSearchParams, useRouter } from "next/navigation";
 import GreenCanvas from "@/components/greens/GreenCanvas";
 import { ChevronLeft, ChevronRight } from "lucide-react";

--- a/components/admin/CourseGridPanel.tsx
+++ b/components/admin/CourseGridPanel.tsx
@@ -1,4 +1,3 @@
-import { useRef, useState, useEffect, useCallback } from "react";
 import GreenCardGridPDF from "@/components/greens/GreenCardGridPDF";
 import { HolePin } from "@/lib/greenCanvas.geometry";
 import { Button } from "@/components/ui/button";

--- a/components/admin/PinEditPanel.tsx
+++ b/components/admin/PinEditPanel.tsx
@@ -4,7 +4,7 @@ import GreenCanvas from "@/components/greens/GreenCanvas";
 import { HolePin, Pin } from "@/lib/greenCanvas.geometry";
 import { Button } from "@/components/ui/button";
 import { MapPin, Save, Flame, Ban, CloudRain } from "lucide-react";
-import { useState, useRef, useEffect } from "react";
+import { useState } from "react";
 import { useContainerSize } from "@/hooks/useContainerSize";
 
 interface PinEditPanelProps {

--- a/components/greens/GreenCanvas.tsx
+++ b/components/greens/GreenCanvas.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { useEffect, useState } from "react";
 import {
   Stage,
   Layer,
@@ -21,7 +20,6 @@ import {
 } from "@/config/constants";
 import {
   Pin,
-  HoleData,
   getOffsetBoundary,
   getOffsetSlope,
   isPointInPolygon,

--- a/components/greens/GreenCardPDF.tsx
+++ b/components/greens/GreenCardPDF.tsx
@@ -1,10 +1,9 @@
 "use client";
 
-import { useEffect, useState } from "react";
 import { Stage, Layer, Path, Line, Circle, Text } from "react-konva";
 import { Fragment } from "react";
 import { HOLE_CONFIGS } from "@/config/holes";
-import { Pin, HoleData } from "@/lib/greenCanvas.geometry";
+import { Pin } from "@/lib/greenCanvas.geometry";
 import {
   getBoundaryIntersectionX,
   getBoundaryIntersectionY,

--- a/components/greens/GreenCardPDFExport.tsx
+++ b/components/greens/GreenCardPDFExport.tsx
@@ -1,10 +1,8 @@
 "use client";
 
-import { useEffect, useState } from "react";
 import { Stage, Layer, Path, Line, Circle, Text, Rect } from "react-konva";
 import { Fragment } from "react";
-import { HOLE_CONFIGS } from "@/config/holes";
-import { Pin, HoleData } from "@/lib/greenCanvas.geometry";
+import { Pin } from "@/lib/greenCanvas.geometry";
 import {
   getBoundaryIntersectionX,
   getBoundaryIntersectionY,


### PR DESCRIPTION
## 概要
リファクタリングで不要になったimportとデバッグ用console.logを削除

## 実施した内容
- admin/cells/page.tsx: 未使用useRef削除
- admin/pdf-preview/page.tsx: 未使用PinSession, api削除
- staff/hole/[id]/page.tsx: 未使用useRef削除
- components/admin/CourseGridPanel.tsx: 未使用useRef, useState, useEffect, useCallback削除
- components/admin/PinEditPanel.tsx: 未使用useRef, useEffect削除
- components/greens/GreenCanvas.tsx: 未使用useEffect, useState, HoleData削除
- components/greens/GreenCardPDF.tsx: 未使用useEffect, useState, HoleData, config削除
- components/greens/GreenCardPDFExport.tsx: 未使用useEffect, useState, HOLE_CONFIGS, HoleData削除
- admin/users/page.tsx: handleDelete内のconsole.log削除

Closes #160